### PR TITLE
Improve publication layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .hugo_build.lock
+public/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # [alexlyttle.github.io](https://alexlyttle.github.io)
 
-Personal website, [blog](alexlyttle.github.io#blog) and summary of my professional [projects](alexlyttle.github.io#code) and [publications](alexlyttle.github.io#publications). Feel free to get in touch with me via the [contact form](alexlyttle.github.io#contact). If you have any feedback, don't hesitate to [raise an Issue](https://github.com/alexlyttle/alexlyttle.github.io/issues/new).
+Personal website, [blog](https://alexlyttle.github.io/posts) and summary of my professional [publications](https://alexlyttle.github.io/publications). If you have any questions or feedback, don't hesitate to [raise an Issue](https://github.com/alexlyttle/alexlyttle.github.io/issues/new).
 
 ## Acknowledgements
 
-- [Font Awesome](https://fontawesome.io)
-- [Academicons](https://jpswalsh.github.io/academicons/)
+- Powered by [Hugo](https://gohugo.io)
+- Uses the [PaperMod](https://github.com/adityatelange/hugo-PaperMod) theme

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -21,26 +21,11 @@ body {
     display: inline;
 }
 
-.post-abstract {
-    margin-top: 10px;
-    margin-bottom: 5px;
-}
-
-.post-entry .post-type {
-    margin-top: 2px;
-}
-
-.post-type {
+.post-categories {
     margin-top: 10px;
     margin-bottom: 5px;
     color: var(--secondary);
     font-size: small;
-}
-
-.post-type .button {
-    margin-left: 0;
-    padding-top: 4px;
-    padding-bottom: 4px;
 }
 
 .post-content a {

--- a/content/publications/2021AJ....161...62N.md
+++ b/content/publications/2021AJ....161...62N.md
@@ -1,6 +1,6 @@
 ---
 title: 'PBjam: A Python Package for Automating Asteroseismology of Solar-like Oscillators'
-authors:
+author:
 - "M.\_B. Nielsen"
 - "G.\_R. Davies"
 - "W.\_H. Ball"
@@ -19,8 +19,8 @@ authors:
 - A. Moya
 - "M.\_N. Lund"
 date: '2021-02-01'
-journal: AJ
-abstract: "Asteroseismology is an exceptional tool for studying stars using the\n\
+publishdate: '2023-10-12'
+description: "Asteroseismology is an exceptional tool for studying stars using the\n\
   \        properties of observed modes of oscillation. So far the process\n     \
   \   of performing an asteroseismic analysis of a star has remained\n        somewhat\
   \ esoteric and inaccessible to nonexperts. In this\n        software paper we describe\
@@ -47,10 +47,10 @@ tags:
 - '1617'
 - '1858'
 - Astrophysics - Solar and Stellar Astrophysics
+journal: AJ
 doi: 10.3847/1538-3881/abcd39
 adsurl: https://ui.adsabs.harvard.edu/abs/2021AJ....161...62N
 adsnote: Provided by the SAO/NASA Astrophysics Data System
 publication_type: article
 bibcode: 2021AJ....161...62N
-publishdate: '2023-10-11'
 ---

--- a/content/publications/2021AJ....161...62N.md
+++ b/content/publications/2021AJ....161...62N.md
@@ -19,7 +19,7 @@ author:
 - A. Moya
 - "M.\_N. Lund"
 date: '2021-02-01'
-publishdate: '2023-10-12'
+publishdate: '2023-10-13'
 description: "Asteroseismology is an exceptional tool for studying stars using the\n\
   \        properties of observed modes of oscillation. So far the process\n     \
   \   of performing an asteroseismic analysis of a star has remained\n        somewhat\
@@ -47,6 +47,8 @@ tags:
 - '1617'
 - '1858'
 - Astrophysics - Solar and Stellar Astrophysics
+categories:
+- Article
 journal: AJ
 doi: 10.3847/1538-3881/abcd39
 adsurl: https://ui.adsabs.harvard.edu/abs/2021AJ....161...62N

--- a/content/publications/2021MNRAS.502.3704A.md
+++ b/content/publications/2021MNRAS.502.3704A.md
@@ -96,7 +96,7 @@ author:
 - Victor Silva Aguirre
 - "Nathalie Theme\xDFl"
 date: '2021-04-01'
-publishdate: '2023-10-12'
+publishdate: '2023-10-13'
 description: "We report the discovery of a warm sub-Saturn, TOI-257b (HD 19916b),\n\
   \        based on data from NASA's Transiting Exoplanet Survey Satellite\n     \
   \   (TESS). The transit signal was detected by TESS and confirmed to\n        be\
@@ -126,6 +126,8 @@ tags:
 - 'stars: individual (TIC 200723869/TOI-257)'
 - Astrophysics - Earth and Planetary Astrophysics
 - Astrophysics - Solar and Stellar Astrophysics
+categories:
+- Article
 journal: MNRAS
 doi: 10.1093/mnras/staa3960
 adsurl: https://ui.adsabs.harvard.edu/abs/2021MNRAS.502.3704A

--- a/content/publications/2021MNRAS.502.3704A.md
+++ b/content/publications/2021MNRAS.502.3704A.md
@@ -1,6 +1,6 @@
 ---
 title: 'TOI-257b (HD 19916b): a warm sub-saturn orbiting an evolved F-type star'
-authors:
+author:
 - Brett C. Addison
 - Duncan J. Wright
 - Belinda A. Nicholson
@@ -96,10 +96,10 @@ authors:
 - Victor Silva Aguirre
 - "Nathalie Theme\xDFl"
 date: '2021-04-01'
-journal: MNRAS
-abstract: "We report the discovery of a warm sub-Saturn, TOI-257b (HD 19916b),\n \
-  \       based on data from NASA's Transiting Exoplanet Survey Satellite\n      \
-  \  (TESS). The transit signal was detected by TESS and confirmed to\n        be\
+publishdate: '2023-10-12'
+description: "We report the discovery of a warm sub-Saturn, TOI-257b (HD 19916b),\n\
+  \        based on data from NASA's Transiting Exoplanet Survey Satellite\n     \
+  \   (TESS). The transit signal was detected by TESS and confirmed to\n        be\
   \ of planetary origin based on radial velocity observations. An\n        analysis\
   \ of the TESS photometry, the MINERVA-Australis, FEROS,\n        and HARPS radial\
   \ velocities, and the asteroseismic data of the\n        stellar oscillations reveals\
@@ -126,10 +126,10 @@ tags:
 - 'stars: individual (TIC 200723869/TOI-257)'
 - Astrophysics - Earth and Planetary Astrophysics
 - Astrophysics - Solar and Stellar Astrophysics
+journal: MNRAS
 doi: 10.1093/mnras/staa3960
 adsurl: https://ui.adsabs.harvard.edu/abs/2021MNRAS.502.3704A
 adsnote: Provided by the SAO/NASA Astrophysics Data System
 publication_type: article
 bibcode: 2021MNRAS.502.3704A
-publishdate: '2023-10-11'
 ---

--- a/content/publications/2021MNRAS.505.2427L.md
+++ b/content/publications/2021MNRAS.505.2427L.md
@@ -15,7 +15,7 @@ author:
 - Sarbani Basu
 - "Rafael A. Garc\xEDa"
 date: '2021-08-01'
-publishdate: '2023-10-12'
+publishdate: '2023-10-13'
 description: "With recent advances in modelling stars using high-precision\n     \
   \   asteroseismology, the systematic effects associated with our\n        assumptions\
   \ of stellar helium abundance (Y) and the mixing-\n        length theory parameter\
@@ -41,6 +41,8 @@ tags:
 - 'stars: fundamental parameters'
 - 'stars: statistics'
 - Astrophysics - Solar and Stellar Astrophysics
+categories:
+- Article
 journal: MNRAS
 doi: 10.1093/mnras/stab1368
 adsurl: https://ui.adsabs.harvard.edu/abs/2021MNRAS.505.2427L

--- a/content/publications/2021MNRAS.505.2427L.md
+++ b/content/publications/2021MNRAS.505.2427L.md
@@ -1,7 +1,7 @@
 ---
 title: Hierarchically modelling Kepler dwarfs and subgiants to improve inference of
   stellar properties with asteroseismology
-authors:
+author:
 - Alexander J. Lyttle
 - Guy R. Davies
 - Tanda Li
@@ -15,36 +15,36 @@ authors:
 - Sarbani Basu
 - "Rafael A. Garc\xEDa"
 date: '2021-08-01'
-journal: MNRAS
-abstract: "With recent advances in modelling stars using high-precision\n        asteroseismology,\
-  \ the systematic effects associated with our\n        assumptions of stellar helium\
-  \ abundance (Y) and the mixing-\n        length theory parameter (\u03B1_MLT) are\n\
-  \        becoming more important. We apply a new method to improve the\n       \
-  \ inference of stellar parameters for a sample of Kepler dwarfs\n        and subgiants\
-  \ across a narrow mass range (0.8  M  1.2 \n        M_\u2299). In this method, we\
-  \ include a statistical treatment of\n        Y and the \u03B1_MLT. We develop a\n\
-  \        hierarchical Bayesian model to encode information about the\n        distribution\
-  \ of Y and \u03B1_MLT in the\n        population, fitting a linear helium enrichment\
-  \ law including an\n        intrinsic spread around this relation and normal distribution\
-  \ in\n        \u03B1_MLT. We test various levels of pooling\n        parameters,\
-  \ with and without solar data as a calibrator. When\n        including the Sun as\
-  \ a star, we find the gradient for the\n        enrichment law, \u0394 Y / \u0394\
-  \ Z =\n        1.05+0.28\xAD0.25 and the mean\n        \u03B1_MLT in the population,\
-  \ \u03BC _\u03B1 =\n        1.90+0.10\xAD0.09. While accounting for the\n      \
-  \  uncertainty in Y and \u03B1_MLT, we are still\n        able to report statistical\
-  \ uncertainties of 2.5 per cent in\n        mass, 1.2 per cent in radius, and 12\
-  \ per cent in age. Our method\n        can also be applied to larger samples that\
-  \ will lead to improved\n        constraints on both the population level inference\
-  \ and the star-\n        by-star fundamental parameters."
+publishdate: '2023-10-12'
+description: "With recent advances in modelling stars using high-precision\n     \
+  \   asteroseismology, the systematic effects associated with our\n        assumptions\
+  \ of stellar helium abundance (Y) and the mixing-\n        length theory parameter\
+  \ (\u03B1_MLT) are\n        becoming more important. We apply a new method to improve\
+  \ the\n        inference of stellar parameters for a sample of Kepler dwarfs\n \
+  \       and subgiants across a narrow mass range (0.8  M  1.2 \n        M_\u2299\
+  ). In this method, we include a statistical treatment of\n        Y and the \u03B1\
+  _MLT. We develop a\n        hierarchical Bayesian model to encode information about\
+  \ the\n        distribution of Y and \u03B1_MLT in the\n        population, fitting\
+  \ a linear helium enrichment law including an\n        intrinsic spread around this\
+  \ relation and normal distribution in\n        \u03B1_MLT. We test various levels\
+  \ of pooling\n        parameters, with and without solar data as a calibrator. When\n\
+  \        including the Sun as a star, we find the gradient for the\n        enrichment\
+  \ law, \u0394 Y / \u0394 Z =\n        1.05+0.28\xAD0.25 and the mean\n        \u03B1\
+  _MLT in the population, \u03BC _\u03B1 =\n        1.90+0.10\xAD0.09. While accounting\
+  \ for the\n        uncertainty in Y and \u03B1_MLT, we are still\n        able to\
+  \ report statistical uncertainties of 2.5 per cent in\n        mass, 1.2 per cent\
+  \ in radius, and 12 per cent in age. Our method\n        can also be applied to\
+  \ larger samples that will lead to improved\n        constraints on both the population\
+  \ level inference and the star-\n        by-star fundamental parameters."
 tags:
 - asteroseismology
 - 'stars: fundamental parameters'
 - 'stars: statistics'
 - Astrophysics - Solar and Stellar Astrophysics
+journal: MNRAS
 doi: 10.1093/mnras/stab1368
 adsurl: https://ui.adsabs.harvard.edu/abs/2021MNRAS.505.2427L
 adsnote: Provided by the SAO/NASA Astrophysics Data System
 publication_type: article
 bibcode: 2021MNRAS.505.2427L
-publishdate: '2023-10-11'
 ---

--- a/content/publications/2021plat.confE..48L.md
+++ b/content/publications/2021plat.confE..48L.md
@@ -1,13 +1,13 @@
 ---
 title: Hierarchically modelling stars to improve inference of stellar properties with
   asteroseismology
-authors:
+author:
 - Alexander J. Lyttle
 date: '2021-10-01'
-journal: null
-abstract: "High-precision asteroseismology has improved estimates of stellar\n   \
-  \     masses, radii, and ages. However, this has revealed inaccuracies\n       \
-  \ in typical assumptions regarding properties such as helium\n        abundance\
+publishdate: '2023-10-12'
+description: "High-precision asteroseismology has improved estimates of stellar\n\
+  \        masses, radii, and ages. However, this has revealed inaccuracies\n    \
+  \    in typical assumptions regarding properties such as helium\n        abundance\
   \ (Y) and the mixing-length theory parameter\n        (\u03B1). We applied a hierarchical\
   \ Bayesian\n        model to a sample of main sequence, low-mass dwarf stars to\n\
   \        encode population level information about Y and\n        \u03B1. We showed\
@@ -19,10 +19,10 @@ abstract: "High-precision asteroseismology has improved estimates of stellar\n  
   \ parameters."
 tags:
 - Zenodo community plato2021
+journal: null
 doi: 10.5281/zenodo.5557059
 adsurl: https://ui.adsabs.harvard.edu/abs/2021plat.confE..48L
 adsnote: Provided by the SAO/NASA Astrophysics Data System
 publication_type: inproceedings
 bibcode: 2021plat.confE..48L
-publishdate: '2023-10-11'
 ---

--- a/content/publications/2021plat.confE..48L.md
+++ b/content/publications/2021plat.confE..48L.md
@@ -4,7 +4,7 @@ title: Hierarchically modelling stars to improve inference of stellar properties
 author:
 - Alexander J. Lyttle
 date: '2021-10-01'
-publishdate: '2023-10-12'
+publishdate: '2023-10-13'
 description: "High-precision asteroseismology has improved estimates of stellar\n\
   \        masses, radii, and ages. However, this has revealed inaccuracies\n    \
   \    in typical assumptions regarding properties such as helium\n        abundance\
@@ -19,6 +19,8 @@ description: "High-precision asteroseismology has improved estimates of stellar\
   \ parameters."
 tags:
 - Zenodo community plato2021
+categories:
+- In Proceedings
 journal: null
 doi: 10.5281/zenodo.5557059
 adsurl: https://ui.adsabs.harvard.edu/abs/2021plat.confE..48L

--- a/content/publications/2022A&A...657A..88B.md
+++ b/content/publications/2022A&A...657A..88B.md
@@ -1,7 +1,7 @@
 ---
 title: CORALIE radial velocity search for companions around evolved stars (CASCADES).
   II. Seismic masses for three red giants orbited by long-period massive planets
-authors:
+author:
 - G. Buldgen
 - G. Ottoni
 - C. Pezzotti
@@ -16,8 +16,8 @@ authors:
 - "G.\_R. Davies"
 - "W.\_H. Ball"
 date: '2022-01-01'
-journal: A&A
-abstract: "Context. The advent of asteroseismology as the golden path to precisely\n\
+publishdate: '2023-10-12'
+description: "Context. The advent of asteroseismology as the golden path to precisely\n\
   \        characterize single stars naturally led to synergies with the\n       \
   \ field of exoplanetology. Today, the precise determination of\n        stellar\
   \ masses, radii and ages for exoplanet-host stars is a\n        driving force in\
@@ -53,10 +53,10 @@ tags:
 - planetary systems
 - Astrophysics - Solar and Stellar Astrophysics
 - Astrophysics - Earth and Planetary Astrophysics
+journal: A&A
 doi: 10.1051/0004-6361/202040079
 adsurl: https://ui.adsabs.harvard.edu/abs/2022A   A...657A..88B
 adsnote: Provided by the SAO/NASA Astrophysics Data System
 publication_type: article
 bibcode: 2022A&A...657A..88B
-publishdate: '2023-10-11'
 ---

--- a/content/publications/2022A&A...657A..88B.md
+++ b/content/publications/2022A&A...657A..88B.md
@@ -16,7 +16,7 @@ author:
 - "G.\_R. Davies"
 - "W.\_H. Ball"
 date: '2022-01-01'
-publishdate: '2023-10-12'
+publishdate: '2023-10-13'
 description: "Context. The advent of asteroseismology as the golden path to precisely\n\
   \        characterize single stars naturally led to synergies with the\n       \
   \ field of exoplanetology. Today, the precise determination of\n        stellar\
@@ -53,6 +53,8 @@ tags:
 - planetary systems
 - Astrophysics - Solar and Stellar Astrophysics
 - Astrophysics - Earth and Planetary Astrophysics
+categories:
+- Article
 journal: A&A
 doi: 10.1051/0004-6361/202040079
 adsurl: https://ui.adsabs.harvard.edu/abs/2022A   A...657A..88B

--- a/content/publications/2022A&A...657A..89P.md
+++ b/content/publications/2022A&A...657A..89P.md
@@ -17,7 +17,7 @@ author:
 - "G.\_R. Davies"
 - "W.\_H. Ball"
 date: '2022-01-01'
-publishdate: '2023-10-12'
+publishdate: '2023-10-13'
 description: "Context. Increasing the number of detected exoplanets is far from\n\
   \        anecdotal, especially for long-period planets that require a\n        long\
   \ duration of observation. More detections imply a better\n        understanding\
@@ -56,6 +56,8 @@ tags:
 - 'stars: fundamental parameters'
 - Astrophysics - Earth and Planetary Astrophysics
 - Astrophysics - Solar and Stellar Astrophysics
+categories:
+- Article
 journal: A&A
 doi: 10.1051/0004-6361/202040080
 adsurl: https://ui.adsabs.harvard.edu/abs/2022A   A...657A..89P

--- a/content/publications/2022A&A...657A..89P.md
+++ b/content/publications/2022A&A...657A..89P.md
@@ -1,7 +1,7 @@
 ---
 title: 'CORALIE radial-velocity search for companions around evolved stars (CASCADES).
   III. A new Jupiter host-star: in-depth analysis of HD 29399 using TESS data'
-authors:
+author:
 - C. Pezzotti
 - G. Ottoni
 - G. Buldgen
@@ -17,9 +17,9 @@ authors:
 - "G.\_R. Davies"
 - "W.\_H. Ball"
 date: '2022-01-01'
-journal: A&A
-abstract: "Context. Increasing the number of detected exoplanets is far from\n   \
-  \     anecdotal, especially for long-period planets that require a\n        long\
+publishdate: '2023-10-12'
+description: "Context. Increasing the number of detected exoplanets is far from\n\
+  \        anecdotal, especially for long-period planets that require a\n        long\
   \ duration of observation. More detections imply a better\n        understanding\
   \ of the statistical properties of exoplanet\n        populations, and detailed\
   \ modelling of their host stars also\n        enables thorough discussions of star-planet\
@@ -56,10 +56,10 @@ tags:
 - 'stars: fundamental parameters'
 - Astrophysics - Earth and Planetary Astrophysics
 - Astrophysics - Solar and Stellar Astrophysics
+journal: A&A
 doi: 10.1051/0004-6361/202040080
 adsurl: https://ui.adsabs.harvard.edu/abs/2022A   A...657A..89P
 adsnote: Provided by the SAO/NASA Astrophysics Data System
 publication_type: article
 bibcode: 2022A&A...657A..89P
-publishdate: '2023-10-11'
 ---

--- a/content/publications/2022MNRAS.511.5597L.md
+++ b/content/publications/2022MNRAS.511.5597L.md
@@ -9,7 +9,7 @@ author:
 - Lindsey M. Carboneau
 - "Rafael A. Garc\xEDa"
 date: '2022-04-01'
-publishdate: '2023-10-12'
+publishdate: '2023-10-13'
 description: "Grid-based modelling is widely used for estimating stellar parameters.\n\
   \        However, stellar model grid is sparse because of the\n        computational\
   \ cost. This paper demonstrates an application of a\n        machine-learning algorithm\
@@ -33,6 +33,8 @@ tags:
 - Astrophysics - Solar and Stellar Astrophysics
 - Astrophysics - Astrophysics of Galaxies
 - Astrophysics - Instrumentation and Methods for Astrophysics
+categories:
+- Article
 journal: MNRAS
 doi: 10.1093/mnras/stac467
 adsurl: https://ui.adsabs.harvard.edu/abs/2022MNRAS.511.5597L

--- a/content/publications/2022MNRAS.511.5597L.md
+++ b/content/publications/2022MNRAS.511.5597L.md
@@ -1,7 +1,7 @@
 ---
 title: 'Modelling stars with Gaussian Process Regression: augmenting stellar model
   grid'
-authors:
+author:
 - Tanda Li
 - Guy R. Davies
 - Alexander J. Lyttle
@@ -9,8 +9,8 @@ authors:
 - Lindsey M. Carboneau
 - "Rafael A. Garc\xEDa"
 date: '2022-04-01'
-journal: MNRAS
-abstract: "Grid-based modelling is widely used for estimating stellar parameters.\n\
+publishdate: '2023-10-12'
+description: "Grid-based modelling is widely used for estimating stellar parameters.\n\
   \        However, stellar model grid is sparse because of the\n        computational\
   \ cost. This paper demonstrates an application of a\n        machine-learning algorithm\
   \ using the Gaussian Process (GP)\n        Regression that turns a sparse model\
@@ -33,10 +33,10 @@ tags:
 - Astrophysics - Solar and Stellar Astrophysics
 - Astrophysics - Astrophysics of Galaxies
 - Astrophysics - Instrumentation and Methods for Astrophysics
+journal: MNRAS
 doi: 10.1093/mnras/stac467
 adsurl: https://ui.adsabs.harvard.edu/abs/2022MNRAS.511.5597L
 adsnote: Provided by the SAO/NASA Astrophysics Data System
 publication_type: article
 bibcode: 2022MNRAS.511.5597L
-publishdate: '2023-10-11'
 ---

--- a/content/publications/2023MNRAS.523...80L.md
+++ b/content/publications/2023MNRAS.523...80L.md
@@ -8,7 +8,7 @@ author:
 - Margarida S. Cunha
 - Alexander J. Lyttle
 date: '2023-07-01'
-publishdate: '2023-10-12'
+publishdate: '2023-10-13'
 description: "The detailed modelling of stellar oscillations is a powerful approach\
   \ to\n        characterizing stars. However, poor treatment of systematics in\n\
   \        theoretical models leads to misinterpretations of stars. Here,\n      \
@@ -27,6 +27,8 @@ tags:
 - 'stars: oscillation'
 - Astrophysics - Solar and Stellar Astrophysics
 - Astrophysics - Instrumentation and Methods for Astrophysics
+categories:
+- Article
 journal: MNRAS
 doi: 10.1093/mnras/stad1406
 adsurl: https://ui.adsabs.harvard.edu/abs/2023MNRAS.523...80L

--- a/content/publications/2023MNRAS.523...80L.md
+++ b/content/publications/2023MNRAS.523...80L.md
@@ -1,36 +1,36 @@
 ---
 title: 'Systematics in asteroseismic modelling: application of a correlated noise
   model for oscillation frequencies'
-authors:
+author:
 - Tanda Li
 - Guy R. Davies
 - Martin Nielsen
 - Margarida S. Cunha
 - Alexander J. Lyttle
 date: '2023-07-01'
-journal: MNRAS
-abstract: "The detailed modelling of stellar oscillations is a powerful approach to\n\
-  \        characterizing stars. However, poor treatment of systematics in\n     \
-  \   theoretical models leads to misinterpretations of stars. Here,\n        we propose\
-  \ a more principled statistical treatment for the\n        systematics to be applied\
-  \ to fitting individual mode frequencies\n        with a typical stellar model grid.\
-  \ We introduce a correlated\n        noise model based on a Gaussian process (GP)\
-  \ kernel to describe\n        the systematics given that mode frequency systematics\
-  \ are\n        expected to be highly correlated. We show that tuning the GP\n  \
-  \      kernel can reproduce general features of frequency variations\n        for\
-  \ changing model input physics and fundamental parameters.\n        Fits with the\
-  \ correlated noise model better recover stellar\n        parameters than traditional\
-  \ methods that either ignore the\n        systematics or treat them as uncorrelated\
-  \ noise."
+publishdate: '2023-10-12'
+description: "The detailed modelling of stellar oscillations is a powerful approach\
+  \ to\n        characterizing stars. However, poor treatment of systematics in\n\
+  \        theoretical models leads to misinterpretations of stars. Here,\n      \
+  \  we propose a more principled statistical treatment for the\n        systematics\
+  \ to be applied to fitting individual mode frequencies\n        with a typical stellar\
+  \ model grid. We introduce a correlated\n        noise model based on a Gaussian\
+  \ process (GP) kernel to describe\n        the systematics given that mode frequency\
+  \ systematics are\n        expected to be highly correlated. We show that tuning\
+  \ the GP\n        kernel can reproduce general features of frequency variations\n\
+  \        for changing model input physics and fundamental parameters.\n        Fits\
+  \ with the correlated noise model better recover stellar\n        parameters than\
+  \ traditional methods that either ignore the\n        systematics or treat them\
+  \ as uncorrelated noise."
 tags:
 - 'methods: statistical'
 - 'stars: oscillation'
 - Astrophysics - Solar and Stellar Astrophysics
 - Astrophysics - Instrumentation and Methods for Astrophysics
+journal: MNRAS
 doi: 10.1093/mnras/stad1406
 adsurl: https://ui.adsabs.harvard.edu/abs/2023MNRAS.523...80L
 adsnote: Provided by the SAO/NASA Astrophysics Data System
 publication_type: article
 bibcode: 2023MNRAS.523...80L
-publishdate: '2023-10-11'
 ---

--- a/content/publications/2023MNRAS.525.5235S.md
+++ b/content/publications/2023MNRAS.525.5235S.md
@@ -1,7 +1,7 @@
 ---
 title: "Asteroseismology of \u03B4 Scuti stars: emulating model grids using a neural\
   \ network"
-authors:
+author:
 - Owen J. Scutt
 - Simon J. Murphy
 - Martin B. Nielsen
@@ -9,8 +9,8 @@ authors:
 - Timothy R. Bedding
 - Alexander J. Lyttle
 date: '2023-11-01'
-journal: MNRAS
-abstract: "Young \u03B4 Scuti (Sct) stars have proven to be valuable\n        asteroseismic\
+publishdate: '2023-10-12'
+description: "Young \u03B4 Scuti (Sct) stars have proven to be valuable\n        asteroseismic\
   \ targets, but obtaining robust uncertainties on\n        their inferred properties\
   \ is challenging. We aim to quantify the\n        random uncertainties in grid-based\
   \ modelling of\n        \u03B4 Sct stars. We apply Bayesian inference\n        using\
@@ -32,10 +32,10 @@ tags:
 - "stars: variables: \u03B4 Scuti"
 - Astrophysics - Solar and Stellar Astrophysics
 - Astrophysics - Instrumentation and Methods for Astrophysics
+journal: MNRAS
 doi: 10.1093/mnras/stad2621
 adsurl: https://ui.adsabs.harvard.edu/abs/2023MNRAS.525.5235S
 adsnote: Provided by the SAO/NASA Astrophysics Data System
 publication_type: article
 bibcode: 2023MNRAS.525.5235S
-publishdate: '2023-10-11'
 ---

--- a/content/publications/2023MNRAS.525.5235S.md
+++ b/content/publications/2023MNRAS.525.5235S.md
@@ -9,7 +9,7 @@ author:
 - Timothy R. Bedding
 - Alexander J. Lyttle
 date: '2023-11-01'
-publishdate: '2023-10-12'
+publishdate: '2023-10-13'
 description: "Young \u03B4 Scuti (Sct) stars have proven to be valuable\n        asteroseismic\
   \ targets, but obtaining robust uncertainties on\n        their inferred properties\
   \ is challenging. We aim to quantify the\n        random uncertainties in grid-based\
@@ -32,6 +32,8 @@ tags:
 - "stars: variables: \u03B4 Scuti"
 - Astrophysics - Solar and Stellar Astrophysics
 - Astrophysics - Instrumentation and Methods for Astrophysics
+categories:
+- Article
 journal: MNRAS
 doi: 10.1093/mnras/stad2621
 adsurl: https://ui.adsabs.harvard.edu/abs/2023MNRAS.525.5235S

--- a/content/publications/2023MNRAS.526.2141W.md
+++ b/content/publications/2023MNRAS.526.2141W.md
@@ -1,7 +1,7 @@
 ---
 title: The evolution of the Milky Way's thin disc radial metallicity gradient with
   K2 asteroseismic ages
-authors:
+author:
 - Emma Willett
 - Andrea Miglio
 - J. Ted Mackereth
@@ -14,10 +14,10 @@ authors:
 - Giada Casali
 - Valeria Grisoni
 date: '2023-12-01'
-journal: MNRAS
-abstract: "The radial metallicity distribution of the Milky Way's disc is an\n   \
-  \     important observational constraint for models of the formation\n        and\
-  \ evolution of our Galaxy. It informs our understanding of the\n        chemical\
+publishdate: '2023-10-12'
+description: "The radial metallicity distribution of the Milky Way's disc is an\n\
+  \        important observational constraint for models of the formation\n      \
+  \  and evolution of our Galaxy. It informs our understanding of the\n        chemical\
   \ enrichment of the Galactic disc and the dynamical\n        processes therein,\
   \ particularly radial migration. We investigate\n        how the metallicity changes\
   \ with guiding radius in the thin disc\n        using a sample of red giant stars\
@@ -47,10 +47,10 @@ tags:
 - 'Galaxy: disc'
 - 'Galaxy: evolution'
 - 'Galaxy: stellar content'
+journal: MNRAS
 doi: 10.1093/mnras/stad2374
 adsurl: https://ui.adsabs.harvard.edu/abs/2023MNRAS.526.2141W
 adsnote: Provided by the SAO/NASA Astrophysics Data System
 publication_type: article
 bibcode: 2023MNRAS.526.2141W
-publishdate: '2023-10-11'
 ---

--- a/content/publications/2023MNRAS.526.2141W.md
+++ b/content/publications/2023MNRAS.526.2141W.md
@@ -14,7 +14,7 @@ author:
 - Giada Casali
 - Valeria Grisoni
 date: '2023-12-01'
-publishdate: '2023-10-12'
+publishdate: '2023-10-13'
 description: "The radial metallicity distribution of the Milky Way's disc is an\n\
   \        important observational constraint for models of the formation\n      \
   \  and evolution of our Galaxy. It informs our understanding of the\n        chemical\
@@ -47,6 +47,9 @@ tags:
 - 'Galaxy: disc'
 - 'Galaxy: evolution'
 - 'Galaxy: stellar content'
+- Astrophysics - Astrophysics of Galaxies
+categories:
+- Article
 journal: MNRAS
 doi: 10.1093/mnras/stad2374
 adsurl: https://ui.adsabs.harvard.edu/abs/2023MNRAS.526.2141W

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,7 +6,7 @@ theme: PaperMod
 params:
   author: Alexander Lyttle
   defaultTheme: auto
-  hideAuthor: true
+  hideAuthor: false
   ShowBreadCrumbs: true
   
   profileMode:

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -96,7 +96,8 @@
   {{- end }}
   {{- if not (.Param "hideMeta") }}
   <footer class="entry-footer">
-    {{- partial "post_meta.html" . -}}
+    <!-- Send dict to post_meta to say that this is a list page -->
+    {{- partial "post_meta.html" (dict "page" . "isList" true) -}}
   </footer>
   {{- end }}
   <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -72,22 +72,6 @@
       {{- .Title }}
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
     </h2>
-    {{- if .Params.authors }}
-    <p>
-      {{- $maxAuthors := 5 }}
-      {{- with .Params.authors }}
-        {{- $authorCount := len . }}
-        {{- range $index, $author := . }}
-          {{- if lt $index $maxAuthors }}
-            {{- if ne $index 0 }}, {{ end }}{{ if (and (eq $authorCount $maxAuthors) (eq $index (sub $authorCount 1))) }}and {{ end }}{{ $author }}
-          {{- else if eq $index $maxAuthors }}
-            et al
-          {{- end -}}
-        {{- end -}}
-        .
-      {{- end -}}
-    </p>
-    {{- end }}
   </header>
   {{- if (ne (.Param "hideSummary") true) }}
   <div class="entry-content">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -67,7 +67,10 @@
   {{- $isHidden := (site.Params.cover.hidden | default site.Params.cover.hiddenInList) }}
   {{- partial "cover.html" (dict "cxt" . "IsHome" true "isHidden" $isHidden) }}
   <header class="entry-header">
-    {{ partial "post_type.html" . }}
+    <!-- Add list of categories -->
+    {{- if .Params.categories }}
+    <p>{{- delimit .Params.categories "&nbsp;&bull;&nbsp;" }}</p>
+    {{- end }}
     <h2>
       {{- .Title }}
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -37,7 +37,8 @@
     {{- end }}
     {{- if not (.Param "hideMeta") }}
     <div class="post-meta">
-      {{- partial "post_meta.html" . -}}
+      <!-- Send dict to post_meta to say that this is not a list page -->
+      {{- partial "post_meta.html" (dict "page" . "isList" false) -}}
       {{- partial "translation_list.html" . -}}
       {{- partial "edit_post.html" . -}}
       {{- partial "post_canonical.html" . -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -21,11 +21,17 @@
     {{- if (or (isset .Params "bibcode") (isset .Params "doi")) }}
     <div class="post-badges">
       {{- if .Params.bibcode }}
-      <a href="https://ui.adsabs.harvard.edu/abs/{{ .Params.bibcode }}"><img src="https://img.shields.io/badge/NASA%20ADS-{{ .Params.bibcode }}-blue" alt="Bibcode {{ .Params.bibcode }}"></a>
+      <a href="https://ui.adsabs.harvard.edu/abs/{{ .Params.bibcode }}">
+        <img src="https://img.shields.io/badge/NASA_ADS-{{ replace .Params.bibcode "-" "--" }}-blue" alt="Bibcode {{ .Params.bibcode }}">
+      </a>
       {{- end }}
       {{- if .Params.doi }}
-      <a href="https://doi.org/{{ .Params.doi }}"><img src="https://img.shields.io/badge/DOI-{{ .Params.doi }}-red" alt="DOI {{ .Params.doi }}"></a>
-      <a href="https://juleskreuer.eu/projekte/citation-badge/"><img src="https://api.juleskreuer.eu/citation-badge.php?doi={{ .Params.doi }}" alt="DOI {{ .Params.doi }}"></a>
+      <a href="https://doi.org/{{ .Params.doi }}">
+        <img src="https://img.shields.io/badge/DOI-{{ replace .Params.doi "-" "--" }}-yellow" alt="DOI {{ .Params.doi }}">
+      </a>
+      <a href="https://juleskreuer.eu/projekte/citation-badge/">
+        <img src="https://img.shields.io/endpoint?color=green&url=https%3A%2F%2Fapi.juleskreuer.eu%2Fcitation-badge.php%3Fdoi%3D{{ .Params.doi }}%26shield" alt="DOI {{ .Params.doi }}">
+      </a>
       {{- end }}
     </div>
     {{- end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,17 @@
 <article class="post-single">
   <header class="post-header">
     {{ partial "breadcrumbs.html" . }}
-    {{ partial "post_type.html" . }}
+    {{- if .Params.categories }}
+    <!-- Add category buttons -->
+    <div class="post-categories">
+      {{- $categories := .Language.Params.Taxonomies.category | default "categories" }}
+      <ul class="post-tags">
+        {{- range ($.GetTerms $categories) }}
+        <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
+        {{- end }}
+      </ul>
+    </div>
+    {{- end }}
     <h1 class="post-title">
       {{ .Title }}
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,11 +8,6 @@
       {{ .Title }}
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
     </h1>
-    {{- if .Params.authors }}
-    <p>
-      {{ delimit .Params.authors ", " ", and " }}.
-    </p>
-    {{- end }}
     {{- if (or (isset .Params "bibcode") (isset .Params "doi")) }}
     <div class="post-badges">
       {{- if .Params.bibcode }}
@@ -22,12 +17,6 @@
       <a href="https://doi.org/{{ .Params.doi }}"><img src="https://img.shields.io/badge/DOI-{{ .Params.doi }}-red" alt="DOI {{ .Params.doi }}"></a>
       <a href="https://juleskreuer.eu/projekte/citation-badge/"><img src="https://api.juleskreuer.eu/citation-badge.php?doi={{ .Params.doi }}" alt="DOI {{ .Params.doi }}"></a>
       {{- end }}
-    </div>
-    {{- end }}
-    {{- if .Params.abstract }}
-    <div class="post-abstract">
-      <h2>Abstract</h2>
-      <p>{{ .Params.abstract }}</p>
     </div>
     {{- end }}
     {{- if .Description }}

--- a/layouts/partials/author-truncated.html
+++ b/layouts/partials/author-truncated.html
@@ -1,0 +1,19 @@
+{{- if or .Params.author site.Params.author }}
+{{- $author := (.Params.author | default site.Params.author) }}
+{{- $author_type := (printf "%T" $author) }}
+{{- if (or (eq $author_type "[]string") (eq $author_type "[]interface {}")) }}
+{{- $maxAuthors := 5 }}
+{{- with $author }}
+  {{- $authorCount := len . }}
+  {{- range $index, $author := . }}
+    {{- if lt $index $maxAuthors }}
+      {{- if ne $index 0 }}, {{ end }}{{ if (and (eq $authorCount $maxAuthors) (eq $index (sub $authorCount 1))) }}and {{ end }}{{ $author }}
+    {{- else if eq $index $maxAuthors }}
+      et al
+    {{- end }}
+  {{- end }}.
+{{- end }}
+{{- else }}
+{{- $author }}
+{{- end }}
+{{- end -}}

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,0 +1,9 @@
+{{- if or .Params.author site.Params.author }}
+{{- $author := (.Params.author | default site.Params.author) }}
+{{- $author_type := (printf "%T" $author) }}
+{{- if (or (eq $author_type "[]string") (eq $author_type "[]interface {}")) }}
+{{- (delimit $author ", " ", and " ) }}.
+{{- else }}
+{{- $author }}
+{{- end }}
+{{- end -}}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,0 +1,29 @@
+{{- $scratch := newScratch }}
+
+{{- if not .page.Date.IsZero -}}
+{{- $scratch.Add "meta" (slice (printf "<span title='%s'>%s</span>" (.page.Date) (.page.Date | time.Format (default "January 2, 2006" site.Params.DateFormat)))) }}
+{{- end }}
+
+{{- if (.page.Param "ShowReadingTime") -}}
+{{- $scratch.Add "meta" (slice (i18n "read_time" .page.ReadingTime | default (printf "%d min" .page.ReadingTime))) }}
+{{- end }}
+
+{{- if (.page.Param "ShowWordCount") -}}
+{{- $scratch.Add "meta" (slice (i18n "words" .page.WordCount | default (printf "%d words" .page.WordCount))) }}
+{{- end }}
+
+{{- if not (.page.Param "hideAuthor") -}}
+{{- if .isList }}
+{{- with (partial "author-truncated.html" .page) }}
+{{- $scratch.Add "meta" (slice .) }}
+{{- end }}
+{{- else }}
+{{- with (partial "author.html" .page) }}
+{{- $scratch.Add "meta" (slice .) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- with ($scratch.Get "meta") }}
+<p>{{- delimit . "&nbsp;&bull;&nbsp;" -}}</p>
+{{- end -}}

--- a/layouts/partials/post_type.html
+++ b/layouts/partials/post_type.html
@@ -1,5 +1,0 @@
-{{- if .Params.publication_type }}
-<div class="post-type">
-  <span class="button">{{ strings.FirstUpper .Params.publication_type }}</span>
-</div>
-{{- end }}

--- a/scripts/update_pubs.py
+++ b/scripts/update_pubs.py
@@ -84,6 +84,21 @@ def get_date(entry: Entry) -> str:
         month = "jan"
     return datetime.strptime(f"{year}-{month}", "%Y-%b").strftime("%Y-%m-%d")
 
+def get_categories(entry: Entry) -> list:
+    """So far only returns the article type as a category."""
+    category = entry.entry_type
+    if category.startswith("in"):
+        words = ["in", category[2:]]
+    elif category.endswith("thesis"):
+        words = [category[:-6], "thesis"]
+    elif category == "misc":
+        words = ["miscellaneous"]
+    elif category == "techreport":
+        words = ["technical", "report"]
+    else:
+        words = [category]
+    return [" ".join(word.capitalize() for word in words)]
+
 def get_metadata(entry: Entry) -> dict:
     """Get metadata from bibtex entry."""
     metadata = {
@@ -93,6 +108,7 @@ def get_metadata(entry: Entry) -> dict:
         "publishdate": datetime.now().strftime("%Y-%m-%d"),  # This is the date the file was created
         "description": get_field(entry, "abstract"),
         "tags": get_tags(entry),
+        "categories": get_categories(entry),
         "journal": get_field(entry, "journal"),
         "doi": get_field(entry, "doi"),
         "adsurl": get_field(entry, "adsurl"),

--- a/scripts/update_pubs.py
+++ b/scripts/update_pubs.py
@@ -88,17 +88,17 @@ def get_metadata(entry: Entry) -> dict:
     """Get metadata from bibtex entry."""
     metadata = {
         "title": get_field(entry, "title"),
-        "authors": get_authors(entry),
+        "author": get_authors(entry),
         "date": get_date(entry),
-        "journal": get_field(entry, "journal"),
-        "abstract": get_field(entry, "abstract"),
+        "publishdate": datetime.now().strftime("%Y-%m-%d"),  # This is the date the file was created
+        "description": get_field(entry, "abstract"),
         "tags": get_tags(entry),
+        "journal": get_field(entry, "journal"),
         "doi": get_field(entry, "doi"),
         "adsurl": get_field(entry, "adsurl"),
         "adsnote": get_field(entry, "adsnote"),
         "publication_type": entry.entry_type,
         "bibcode": entry.key,
-        "publishdate": datetime.now().strftime("%Y-%m-%d"),
     }
     return metadata
 


### PR DESCRIPTION
Change the publication front matter to conform to the Hugo standard. This simplifies the layout and makes their entry more similar to a blog post.

- [x] 'authors' change to 'author'
- [x] 'abstract' changes to 'description'
- [x] put publication type in 'categories'
- [x] show categories above listing